### PR TITLE
Response - can't insert into closed containers (género)

### DIFF
--- a/Spanish Language.i7x
+++ b/Spanish Language.i7x
@@ -3476,7 +3476,7 @@ Section 3.1.1.1 - Standard actions concerning the actor's possessions
 [ Inserting it into ]
 
     can't insert something into itself rule response (A) is "No puedes poner un objeto dentro de sí mismo.".
-    can't insert into closed containers rule response (A) is "[The second noun] está[n] cerrad[o].".
+    can't insert into closed containers rule response (A) is "[The second noun] está[n] cerrad[o second noun].".
     can't insert into what's not a container rule response (A) is "No se pueden meter cosas dentro [del second noun].".
     can't insert clothes being worn rule response (A) is "(primero te [lo] quitas)[command clarification break]".
     can't insert if this exceeds carrying capacity rule response (A) is "No queda sitio en [the second noun].".


### PR DESCRIPTION
Hola!

He notado que la respuesta de que un contenedor está cerrado al introducir un objeto se escribe con el género incorrecto en las siguientes condiciones:

* contenedor (f) cerrado (ej, "La taquilla").
* objeto (m) (ej. "El pase").

Al escribir `poner pase en taquilla`, la respuesta es `La taquilla está cerrado.`.

Espero que la corrección no tenga ningún efecto imprevisto. ¿Qué te parece? Gracias!